### PR TITLE
Further alterations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,162 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/control/src/orca_quest/adapter.py
+++ b/control/src/orca_quest/adapter.py
@@ -4,6 +4,7 @@ from tornado.escape import json_decode
 
 from odin.adapters.adapter import ApiAdapter, ApiAdapterResponse, request_types, response_types
 from odin.adapters.parameter_tree import ParameterTreeError
+from odin.util import decode_request_body
 
 from orca_quest.controller import OrcaController, OrcaError
 
@@ -53,7 +54,7 @@ class OrcaAdapter(ApiAdapter):
         return ApiAdapterResponse(response, content_type=content_type,
                                   status_code=status_code)
 
-    @request_types('application/json')
+    @request_types('application/json',"application/vnd.odin-native")
     @response_types('application/json', default='application/json')
     def put(self, path, request):
         """Handle an HTTP PUT request.
@@ -64,25 +65,19 @@ class OrcaAdapter(ApiAdapter):
         :param request: HTTP request object
         :return: an ApiAdapterResponse object containing the appropriate response
         """
-
-        content_type = 'application/json'
-
         try:
-            data = json_decode(request.body)
+            data = decode_request_body(request)
             self.camera.set(path, data)
             response = self.camera.get(path)
-            status_code = 200
-        except OrcaError as e:
-            response = {'error': str(e)}
-            status_code = 400
-        except (TypeError, ValueError) as e:
-            response = {'error': 'Failed to decode PUT request body: {}'.format(str(e))}
-            status_code = 400
+            content_type = "applicaiton/json"
+            status = 200
 
-        logging.debug(response)
+        except ParameterTreeError as param_error:
+            response = {'response': 'TriggerAdapter PUT error: {}'.format(param_error)}
+            content_type = 'application/json'
+            status = 400
 
-        return ApiAdapterResponse(response, content_type=content_type,
-                                  status_code=status_code)
+        return ApiAdapterResponse(response, content_type=content_type, status_code=status)
 
     def delete(self, path, request):
         """Handle an HTTP DELETE request.

--- a/control/src/orca_quest/adapter.py
+++ b/control/src/orca_quest/adapter.py
@@ -24,7 +24,7 @@ class OrcaAdapter(ApiAdapter):
         ]
 
         status_bg_task_enable = bool(self.options.get('status_bg_task_enable', 1))
-        status_bg_task_interval = int(self.options.get('status_bg_task_interval', 1))
+        status_bg_task_interval = float(self.options.get('status_bg_task_interval', 1))
 
         # Create acquisition controller
         self.camera = OrcaController(endpoints, names,

--- a/control/src/orca_quest/adapter.py
+++ b/control/src/orca_quest/adapter.py
@@ -21,7 +21,7 @@ class OrcaAdapter(ApiAdapter):
             item.strip() for item in self.options.get('camera_endpoint', None).split(",")
         ]
         names = [
-            item.strip() for item in self.options.get('camera_name', 'camera_1').split(",")
+            item.strip() for item in self.options.get('camera_name', None).split(",")
         ]
 
         status_bg_task_enable = bool(self.options.get('status_bg_task_enable', 1))

--- a/control/src/orca_quest/controller.py
+++ b/control/src/orca_quest/controller.py
@@ -15,7 +15,7 @@ class OrcaController():
 
         # Internal variables
         self.cameras = []
-        camtrees = []
+        camtrees = {}
         tree = {}
 
         self.status_bg_task_enable = status_bg_task_enable
@@ -27,7 +27,7 @@ class OrcaController():
 
             # Store in list of cameras and put tree in list of trees
             self.cameras.append(camera)
-            camtrees.append(camera.tree)
+            camtrees[names[i]] = camera.tree
 
         # Array of camera trees becomes real parameter tree
         tree['cameras'] = camtrees

--- a/control/src/orca_quest/controller.py
+++ b/control/src/orca_quest/controller.py
@@ -15,21 +15,31 @@ class OrcaController():
 
         # Internal variables
         self.cameras = []
-        camtrees = {}
-        tree = {}
+
+        self.endpoints = endpoints
+        self.names = names
 
         self.status_bg_task_enable = status_bg_task_enable
         self.status_bg_task_interval = status_bg_task_interval
 
-        for i in range((len(endpoints))):
-            # For each desired camera, create OrcaCamera with name and endpoint
-            camera = OrcaCamera(endpoints[i], names[i], self.status_bg_task_enable, self.status_bg_task_interval)
+        # Also builds the tree
+        self._connect_cameras()
 
-            # Store in list of cameras and put tree in list of trees
+    def _connect_cameras(self, value=None):
+        """Build the parameter tree and attempt to connect the cameras to it."""
+        if len(self.cameras) > 0:
+            for camera in self.cameras:
+                camera._close_connection()
+        self.cameras = []
+        camtrees = {}
+        tree = {}
+
+        for i in range(len(self.endpoints)):
+            camera = OrcaCamera(self.endpoints[i], self.names[i], self.status_bg_task_enable, self.status_bg_task_interval)
             self.cameras.append(camera)
-            camtrees[names[i]] = camera.tree
-
-        # Array of camera trees becomes real parameter tree
+            camtrees[self.names[i]] = camera.tree
+        
+        # Array of camera trees becomes a real Parameter Tree
         tree['cameras'] = camtrees
         self.param_tree = ParameterTree(tree)
 

--- a/control/src/orca_quest/orca_camera.py
+++ b/control/src/orca_quest/orca_camera.py
@@ -1,5 +1,5 @@
-from odin_data.ipc_channel import IpcChannel
-from odin_data.ipc_message import IpcMessage
+from odin_data.control.ipc_channel import IpcChannel
+from odin_data.control.ipc_message import IpcMessage
 
 from tornado.ioloop import PeriodicCallback
 

--- a/control/src/orca_quest/orca_camera.py
+++ b/control/src/orca_quest/orca_camera.py
@@ -149,9 +149,9 @@ class OrcaCamera():
 
     def status_ioloop_callback(self):
         """Periodic callback task to update camera status."""
-        if self.error_consecutive >= 10:
+        if self.error_consecutive >= 50:
             # After 10 consecutive errors, halt the background task
-            logging.debug("Multiple consecutive errors in camera response. Halting periodic request task.")
+            logging.error("Multiple consecutive errors in camera response. Halting periodic request task.")
             self.stop_background_tasks()
         self.get_status_config(msg='status', silence_reply=True)
         self.get_status_config(msg='request_configuration', silence_reply=True)


### PR DESCRIPTION
A few improvements to the adapter processes.

# Changes
\+ ParameterTree uses camera names as paths instead of array indices
\+ Tree building is in its own function to allow for reconnect capability
\~ Adapter: config options and put change
\~ Consecutive errors stop background task requests to prevent queue getting clogged (background task can be restarted via `background_task/enable` in the tree)
\~ Config and status messages use same function, `get_status_config`